### PR TITLE
Tab view

### DIFF
--- a/Sequor.xcodeproj/project.pbxproj
+++ b/Sequor.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		AD1F0626236760CD00F74D9A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AD1F0624236760CD00F74D9A /* LaunchScreen.storyboard */; };
 		AD1F0631236760CD00F74D9A /* SequorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1F0630236760CD00F74D9A /* SequorTests.swift */; };
 		AD1F063C236760CD00F74D9A /* SequorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD1F063B236760CD00F74D9A /* SequorUITests.swift */; };
+		ADBEB00923743CB9001534CD /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBEB00823743CB9001534CD /* DashboardView.swift */; };
+		ADBEB00B23743E12001534CD /* CouponsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBEB00A23743E12001534CD /* CouponsView.swift */; };
+		ADBEB00D2374423D001534CD /* PurchaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBEB00C2374423D001534CD /* PurchaseView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +57,9 @@
 		AD1F063B236760CD00F74D9A /* SequorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequorUITests.swift; sourceTree = "<group>"; };
 		AD1F063D236760CD00F74D9A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AD1F0649236761BD00F74D9A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		ADBEB00823743CB9001534CD /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
+		ADBEB00A23743E12001534CD /* CouponsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponsView.swift; sourceTree = "<group>"; };
+		ADBEB00C2374423D001534CD /* PurchaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +154,9 @@
 				AD1F061D236760CC00F74D9A /* HomeView.swift */,
 				13BFC8E62368435500BE20D0 /* LoginView.swift */,
 				132F7DC7236858AF00ACE585 /* AccountView.swift */,
+				ADBEB00823743CB9001534CD /* DashboardView.swift */,
+				ADBEB00A23743E12001534CD /* CouponsView.swift */,
+				ADBEB00C2374423D001534CD /* PurchaseView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -303,9 +312,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ADBEB00D2374423D001534CD /* PurchaseView.swift in Sources */,
 				AD1F061A236760CC00F74D9A /* AppDelegate.swift in Sources */,
+				ADBEB00923743CB9001534CD /* DashboardView.swift in Sources */,
 				AD1F061C236760CC00F74D9A /* SceneDelegate.swift in Sources */,
 				13BFC8E72368435500BE20D0 /* LoginView.swift in Sources */,
+				ADBEB00B23743E12001534CD /* CouponsView.swift in Sources */,
 				AD1F061E236760CC00F74D9A /* HomeView.swift in Sources */,
 				132F7DC8236858AF00ACE585 /* AccountView.swift in Sources */,
 			);

--- a/Sequor.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/Sequor.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string></string>
+</dict>
+</plist>

--- a/Sequor/Views/AccountView.swift
+++ b/Sequor/Views/AccountView.swift
@@ -1,11 +1,3 @@
-//
-//  AccountView.swift
-//  Sequor
-//
-//  Created by Mattia Righetti on 29/10/2019.
-//  Copyright © 2019 Anton Roslund. All rights reserved.
-//
-
 import SwiftUI
 
 struct AccountView: View {

--- a/Sequor/Views/CouponsView.swift
+++ b/Sequor/Views/CouponsView.swift
@@ -1,0 +1,24 @@
+//
+//  CoupunsView.swift
+//  Sequor
+//
+//  Created by Anton Roslund on 2019-11-07.
+//  Copyright © 2019 Anton Roslund. All rights reserved.
+//
+
+import SwiftUI
+
+struct CouponsView: View {
+    var body: some View {
+        NavigationView {
+            Text("Coupons View")
+            .navigationBarTitle("Coupons", displayMode: .inline)
+        }
+    }
+}
+
+struct CouponsView_Previews: PreviewProvider {
+    static var previews: some View {
+        CouponsView()
+    }
+}

--- a/Sequor/Views/CouponsView.swift
+++ b/Sequor/Views/CouponsView.swift
@@ -1,11 +1,3 @@
-//
-//  CoupunsView.swift
-//  Sequor
-//
-//  Created by Anton Roslund on 2019-11-07.
-//  Copyright © 2019 Anton Roslund. All rights reserved.
-//
-
 import SwiftUI
 
 struct CouponsView: View {

--- a/Sequor/Views/DashboardView.swift
+++ b/Sequor/Views/DashboardView.swift
@@ -1,0 +1,24 @@
+//
+//  DashboardView.swift
+//  Sequor
+//
+//  Created by Anton Roslund on 2019-11-07.
+//  Copyright © 2019 Anton Roslund. All rights reserved.
+//
+
+import SwiftUI
+
+struct DashboardView: View {
+    var body: some View {
+        NavigationView {
+            Text("Dashbard View")
+            .navigationBarTitle("Seqour CO₂", displayMode: .inline)
+        }
+    }
+}
+
+struct DashboardView_Previews: PreviewProvider {
+    static var previews: some View {
+        DashboardView()
+    }
+}

--- a/Sequor/Views/DashboardView.swift
+++ b/Sequor/Views/DashboardView.swift
@@ -1,11 +1,3 @@
-//
-//  DashboardView.swift
-//  Sequor
-//
-//  Created by Anton Roslund on 2019-11-07.
-//  Copyright © 2019 Anton Roslund. All rights reserved.
-//
-
 import SwiftUI
 
 struct DashboardView: View {

--- a/Sequor/Views/HomeView.swift
+++ b/Sequor/Views/HomeView.swift
@@ -1,31 +1,38 @@
 import SwiftUI
 
 struct HomeView: View {
-    @State private var selection = 1
-    @State private var showLoginView: Bool = true
+    @State private var selection = 3
 
     var body: some View {
         TabView(selection: $selection) {
-            
-            Text("Dashboard View").tabItem {
+            Text("Home View").tabItem {
+                Image(systemName: "house")
+                Text("Home")
+            }.tag(1)
+            PurchaseView().tabItem {
+                Image(systemName: "cart")
+                Text("Purchase")
+            }.tag(2)
+            DashboardView().tabItem {
                 Image(systemName: "cloud")
                 Text("Dashboard")
-            }.tag(1)
-            
-            Text("Coupuns View").tabItem {
+            }.tag(3)
+            CouponsView().tabItem {
                 Image(systemName: "tray.full.fill")
                 Text("Copouns")
-            }.tag(2)
-            
+            }.tag(4)
             AccountView().tabItem {
-                Image(systemName: "person.circle")
-                Text("Account")
-            }.tag(3)
-            
-        }.edgesIgnoringSafeArea(.top)
-        .sheet(isPresented: $showLoginView) {
-            LoginView(showLoginView: self.$showLoginView)
+                Image(systemName: "person")
+                Text("Profile")
+            }.tag(5)
         }
+        .accentColor(.green)
+        .edgesIgnoringSafeArea(.top)
+    }
+
+    init() {
+        // Probably not the best way to do this, but it works and sets it for all views
+        UINavigationBar.appearance().backgroundColor = .green
     }
 }
 

--- a/Sequor/Views/PurchaseView.swift
+++ b/Sequor/Views/PurchaseView.swift
@@ -1,0 +1,24 @@
+//
+//  PushaseView.swift
+//  Sequor
+//
+//  Created by Anton Roslund on 2019-11-07.
+//  Copyright © 2019 Anton Roslund. All rights reserved.
+//
+
+import SwiftUI
+
+struct PurchaseView: View {
+    var body: some View {
+        NavigationView {
+            Text("PurchaseView")
+                .navigationBarTitle("Purchase", displayMode: .inline)
+        }
+    }
+}
+
+struct PurchaseView_Previews: PreviewProvider {
+    static var previews: some View {
+        PurchaseView()
+    }
+}

--- a/Sequor/Views/PurchaseView.swift
+++ b/Sequor/Views/PurchaseView.swift
@@ -1,11 +1,3 @@
-//
-//  PushaseView.swift
-//  Sequor
-//
-//  Created by Anton Roslund on 2019-11-07.
-//  Copyright © 2019 Anton Roslund. All rights reserved.
-//
-
 import SwiftUI
 
 struct PurchaseView: View {


### PR DESCRIPTION
I have changed the TabBar interface to better reflect the current interface in the Trenord app.
The point is to only implement the **Dashboard** and **Coupons** tabs. 

The **Purchase** tab can be used to mock tickets. Basically, just a button to either create and activate a ticket or destroy an active ticket. The same reasoning goes for the **Profile**, it can be used to select the user we want to test with, no need for authentication/registration/login.

<img width="300" alt="Screenshot 2019-11-07 at 13 24 01" src="https://user-images.githubusercontent.com/3624210/68389007-353f8700-0162-11ea-8b39-f79d8dda8607.png">
